### PR TITLE
Set NO_ENERGY_AWARE in sched_features

### DIFF
--- a/profiles/gaming
+++ b/profiles/gaming
@@ -30,6 +30,9 @@ nex /dev/stune/top-app/schedtune.boost 6
 nex /dev/stune/foreground/schedtune.boost 1
 nex /dev/stune/top-app/schedtune.prefer_idle 1
 
+# Set NO_ENERGY_AWARE because we want performance
+nex /sys/kernel/debug/sched_features NO_ENERGY_AWARE
+
 # CPU
 nex /sys/module/cpu_input_boost/parameters/input_boost_duration 128
 


### PR DESCRIPTION
Need to set NO_ENERGY_AWARE because we don't want kernel to be energy aware, we want performance