### PR TITLE
Enable/Disable EAS accord. to profiles

### DIFF
--- a/nexus/battery
+++ b/nexus/battery
@@ -1,12 +1,12 @@
 #!/system/bin/sh
+# NeXus Tweaks
 
-# Since we gonna check lots of files existence 
-# and change its perms to rw-r-r (0644)
-function nex () {
-	if [ -e $1 ]; then
-	chmod 0644 $1
-	echo $2 > $1
-	fi
+# $1:filepath $2:value
+nex() {
+  [ -e "$1" ] && {
+    chmod 0644 $1
+    echo $2 > $1
+  }
 }
 
 # Kernel
@@ -29,6 +29,9 @@ nex /proc/sys/vm/swappiness 60
 nex /dev/stune/top-app/schedtune.boost 1
 nex /dev/stune/foreground/schedtune.boost 0
 nex /dev/stune/top-app/schedtune.prefer_idle 0
+
+# EAS
+nex /proc/sys/kernel/sched_energy_aware 1
 
 # CPU
 nex /sys/module/cpu_input_boost/parameters/input_boost_duration 0
@@ -57,12 +60,11 @@ nex /sys/devices/system/cpu/cpu4/cpufreq/schedutil/iowait_boost_enable 0
 nex /sys/devices/system/cpu/cpu0/cpufreq/schedutil/up_rate_limit_us 500
 nex /sys/devices/system/cpu/cpu4/cpufreq/schedutil/up_rate_limit_us 500
 
-# block
-for queue in /sys/block/*/queue
-do
-echo 128 > "${queue}"/nr_requests
-echo 0 > "${queue}"/rq_affinity
-echo 0 > "${queue}"/nomerges
+# I/O Block
+for queue in /sys/block/*/queue/; do
+  nex "${queue}nr_requests" 128
+  nex "${queue}rq_affinity" 0
+  nex "${queue}nomerges" 0
 done
 
 # Notify nexus deamon know that we're done here

--- a/nexus/common
+++ b/nexus/common
@@ -1,12 +1,12 @@
 #!/system/bin/sh
+# NeXus Tweaks
 
-# Since we gonna check lots of files existence 
-# and change its perms to rw-r-r (0644)
-function nex () {
-	if [ -e $1 ]; then
-	chmod 0644 $1
-	echo $2 > $1
-	fi
+# $1:filepath $2:value
+nex() {
+  [ -e "$1" ] && {
+    chmod 0644 $1
+    echo $2 > $1
+  }
 }
 
 # Kernel
@@ -46,14 +46,12 @@ nex /sys/module/msm_performance/parameters/touchboost 0
 nex /proc/sys/debug/exception-trace 0
 
 # Disable some kernel debugging
-for i in /sys/module/*/parameters/debug_mask
-do 
-echo 0 > $i
+for i in /sys/module/*/parameters/debug_mask; do
+  nex "$i" 0
 done
 
-for i in /sys/module/*/parameters/debug_level 
-do 
-echo 0 > $i
+for i in /sys/module/*/parameters/debug_level; do 
+  nex "$i" 0
 done
 
 # Disable some more debugging
@@ -84,12 +82,11 @@ nex /proc/sys/net/ipv4/tcp_ecn 1
 nex /proc/sys/net/ipv4/tcp_fastopen 3
 nex /proc/sys/net/ipv4/tcp_timestamps 0
 
-#
-for queue in /sys/block/*/queue
-do
-echo 128 > "${queue}"/read_ahead_kb
-echo 0 > "${queue}"/add_random
-echo 0 > "${queue}"/iostats
-echo 0 > "${queue}"/rotational
-done
 
+# I/O Blocks
+for queue in /sys/block/*/queue/; do
+  nex "${queue}read_ahead_kb" 128
+  nex "${queue}add_random" 0
+  nex "${queue}iostats" 0
+  nex "${queue}rotational" 0  
+done

--- a/nexus/efficient
+++ b/nexus/efficient
@@ -1,12 +1,11 @@
 #!/system/bin/sh
 
-# Since we gonna check lots of files existence 
-# and change its perms to rw-r-r (0644)
-function nex () {
-	if [ -e $1 ]; then
-	chmod 0644 $1
-	echo $2 > $1
-	fi
+# $1:filepath $2:value
+nex() {
+  [ -e "$1" ] && {
+    chmod 0644 $1
+    echo $2 > $1
+  }
 }
 
 # Kernel
@@ -29,6 +28,9 @@ nex /proc/sys/vm/swappiness 75
 nex /dev/stune/top-app/schedtune.boost 5
 nex /dev/stune/foreground/schedtune.boost 1
 nex /dev/stune/top-app/schedtune.prefer_idle 1
+
+# EAS
+nex /proc/sys/kernel/sched_energy_aware 0
 
 # CPU
 nex /sys/module/cpu_input_boost/parameters/input_boost_duration 64
@@ -57,12 +59,11 @@ nex /sys/devices/system/cpu/cpu4/cpufreq/schedutil/iowait_boost_enable 0
 nex /sys/devices/system/cpu/cpu0/cpufreq/schedutil/up_rate_limit_us 500
 nex /sys/devices/system/cpu/cpu4/cpufreq/schedutil/up_rate_limit_us 500
 
-# Block
-for queue in /sys/block/*/queue
-do
-echo 32 > "${queue}"/nr_requests
-echo 2 > "${queue}"/rq_affinity
-echo 0 > "${queue}"/nomerges
+# I/O Blocks
+for queue in /sys/block/*/queue/; do
+  nex "${queue}nr_requests" 32
+  nex "${queue}rq_affinity" 2
+  nex "${queue}nomerges" 0
 done
 
 # Notify nexus deamon know that we're done here

--- a/nexus/gaming
+++ b/nexus/gaming
@@ -1,12 +1,12 @@
 #!/system/bin/sh
+# NeXus Tweaks
 
-# Since we gonna check lots of files existence 
-# and change its perms to rw-r-r (0644)
-function nex () {
-	if [ -e $1 ]; then
-	chmod 0644 $1
-	echo $2 > $1
-	fi
+# $1:filepath $2:value
+nex() {
+  [ -e "$1" ] && {
+    chmod 0644 $1
+    echo $2 > $1
+  }
 }
 
 # Kernel
@@ -29,6 +29,9 @@ nex /proc/sys/vm/swappiness 100
 nex /dev/stune/top-app/schedtune.boost 6
 nex /dev/stune/foreground/schedtune.boost 1
 nex /dev/stune/top-app/schedtune.prefer_idle 1
+
+# EAS
+nex /proc/sys/kernel/sched_energy_aware 0
 
 # CPU
 nex /sys/module/cpu_input_boost/parameters/input_boost_duration 128
@@ -57,12 +60,11 @@ nex /sys/devices/system/cpu/cpu4/cpufreq/schedutil/iowait_boost_enable 1
 nex /sys/devices/system/cpu/cpu0/cpufreq/schedutil/up_rate_limit_us 500
 nex /sys/devices/system/cpu/cpu4/cpufreq/schedutil/up_rate_limit_us 500
 
-# Block
-for queue in /sys/block/*/queue
-do
-echo 64 > "${queue}"/nr_requests
-echo 2 > "${queue}"/rq_affinity
-echo 2 > "${queue}"/nomerges
+# I/O Blocks
+for queue in /sys/block/*/queue/; do
+  nex "${queue}nr_requests" 64
+  nex "${queue}rq_affinity" 2
+  nex "${queue}nomerges" 2
 done
 
 # Notify nexus deamon know that we're done here

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -1,2 +1,11 @@
 #!/system/bin/sh
-#wip
+# NeXus Tweaks
+
+# Improve boot time by tuning I/O scheduler parameters (Cherrypicked from https://source.android.com/devices/tech/perf/boot-times)
+ write "/sys/block/sda/queue/iostats" "0"
+ write "/sys/block/sda/queue/scheduler" "cfq"
+ write "/sys/block/sda/queue/iosched/slice_idle" "0"
+ write "/sys/block/sda/queue/read_ahead_kb" "2048"
+ write "/sys/block/sda/queue/nr_requests" "256"
+ write "/sys/block/dm-0/queue/read_ahead_kb" "2048"
+ write "/sys/block/dm-1/queue/read_ahead_kb" "2048"


### PR DESCRIPTION
Docs: https://www.kernel.org/doc/html/v5.9/admin-guide/sysctl/kernel.html#sched-energy-aware and https://source.android.com/devices/tech/perf/boot-times